### PR TITLE
Format balances as locale string.

### DIFF
--- a/components/Wallet/ActiveWallet.tsx
+++ b/components/Wallet/ActiveWallet.tsx
@@ -669,7 +669,7 @@ const ActiveWallet: React.FC<{ css?: Stitches.CSS }> = ({ css }) => {
 
         <Button
           variant="primary"
-          disabled={txDisabled != false || Number(juiceAmount) == 0}
+          disabled={txDisabled != false || +juiceAmount == 0}
           css={{
             width: "100%",
             height: "auto",
@@ -691,9 +691,9 @@ const ActiveWallet: React.FC<{ css?: Stitches.CSS }> = ({ css }) => {
               : handleTx(TxTypes.withdraw)
           }
         >
-          {Number(juiceAmount) > 0 && transactionType === "deposit" ? (
+          {+juiceAmount > 0 && transactionType === "deposit" ? (
             `Deposit ${juiceAmount} JUICE to Juicenet`
-          ) : Number(juiceAmount) > 0 && transactionType === "withdraw" ? (
+          ) : +juiceAmount > 0 && transactionType === "withdraw" ? (
             `Withdraw ${juiceAmount} JUICE from Juicenet`
           ) : (
             <>Enter a JUICE Amount to transfer</>

--- a/state/actions/wallet.tsx
+++ b/state/actions/wallet.tsx
@@ -238,10 +238,10 @@ export const updateBalances = async () => {
         optionalAddress: contractAddress || undefined,
       });
 
-    state.balances.vnl = Number(vnlBalance).toFixed(3);
-    state.balances.eth = Number(ethBalance).toFixed(3);
-    state.balances.matic = Number(maticBalance).toFixed(3);
-    state.balances.juice = Number(juiceBalance).toFixed(3);
+    state.balances.vnl = Number(vnlBalance).toLocaleString();
+    state.balances.eth = Number(ethBalance).toLocaleString();
+    state.balances.matic = Number(maticBalance).toLocaleString();
+    state.balances.juice = Number(juiceBalance).toLocaleString();
 
     state.rawBalances.vnl = parseUnits(vnlBalance || "0", vnlDecimals);
     state.rawBalances.eth = parseUnits(ethBalance || "0");

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -14,7 +14,7 @@ export const isValidEmail = (email?: string) =>
 type Nullable<T> = T | null | undefined;
 
 export const formatJuice = (amount: Nullable<ethers.BigNumberish>) =>
-  Number(ethers.utils.formatUnits(amount || 0, juiceDecimals)).toFixed(3);
+  Number(ethers.utils.formatUnits(amount || 0, juiceDecimals)).toLocaleString();
 
 export const parseJuice = (amount: Nullable<string | number>) =>
   ethers.utils.parseUnits(amount?.toString() || '0', juiceDecimals);


### PR DESCRIPTION
Important consideration here, since we are using `Number` properties here, both `toFixed` and `toLocaleString` DOES lose precision on large numbers. This can be a non issue as we always deal with `BigNumber` behind the scenes, but maybe important to remember that numbers displayed on screen may not be exact. 

For example:
```
Number(100000000000000000001).toFixed()
// '100000000000000000000'

Number(100000000000000000001).toLocaleString()
// '100,000,000,000,000,000,000'
```

This can be resolved by using external libraries like big.js as ethers formating utils doesn't seem have locale formatting options.